### PR TITLE
refactor: separate functions into different files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # mc-labels-and-annotations
 
-This Helm chart is maintained by MapColonies.
-It provides predefined labels and annotations through helper templates to streamline the deployment
-of Kubernetes applications.
+This Helm chart provides MapColonies predefined labels and annotations through helper templates to streamline Kubernetes application deployments.
 
-The `_helpers.tpl` file includes templates for standard Kubernetes labels, ensuring uniformity across deployments.
+## Features
+- Standardized Kubernetes labels and annotations
+- Global and local metadata configuration
+- Built-in validation for metadata values
+- Helm template helpers for easy integration
 
-## Usage:
-To use this package and include the labels in your repository, add the package as a dependency:
+## Installation
+
+Add this chart as a dependency in your `Chart.yaml`:
 
 ```yaml
 dependencies:
@@ -16,7 +19,15 @@ dependencies:
     repository: oci://artifactory.io/helm/infra
 ```
 
-In your Kubernetes manifest templates, reference the helper templates to add labels and annotations:
+Then run:
+```bash
+helm dependency update
+```
+
+## Usage
+
+### Template Integration
+Add the following to your Kubernetes manifest templates:
 
 ```yaml
 metadata:
@@ -26,27 +37,55 @@ metadata:
     {{ include "mc-labels-and-annotations.annotations" . | nindent 4 }}
 ```
 
-To ensure the labels are properly generated, define your metadata values in values.yaml.
-By default, the chart retrieves values from mcMetadata under global, ensuring consistent labeling across deployments.  
-If a specific value exists outside `global`, it will override the global value for that key.
+### Configuration
+Define "mcLabels" in `values.yaml`. Values can be set globally or overridden locally:
 
 ```yaml
-general:
-  mcMetadata:
-    createdBy: "Michal" 
+global:
+  mcLabels:
+    environment: "development"
+    createdBy: "Person"
     component: "infrastructure"
     partOf: "Monitoring"
-    releaseVersion: "v1.1.0"
-    owner: "infra"
-    gisDomain: ""
 
-mcMetadata:
-  component: "backend"  # Overrides global.mcMetadata.component
-  owner: "3d" # Overrides global.mcMetadata.owner
+mcLabels:
+  component: "backend" # Overrides global.mcLabels.component
+  owner: "3d" # Overrides global.mcLabels.owner
 ```
 
-## Validation:
-The chart includes validation logic to ensure that required label values are provided and arein the expected
-formats. For instance, it checks that fields like createdBy and partOf are not empty, and that component 
-matches one of the predefined categories such as "frontend", "backend", or "infrastructure".
-This validation helps maintain consistency and prevents deployment errors due to misconfigured labels.
+### Validation Rules
+
+The chart validates the following metadata fields:
+
+| Field | Required | Valid Values | Notes |
+|----------------|----------|---------------------|----|
+| environment | Yes | development, production,stage | |
+| createdBy | Yes | non-empty string   | The person who deployed it |
+| component | Yes | frontend, backend, database, proxy-server, cache-server, infrastructure | Optional when deploying service |
+| partOf | Yes | non-empty string | |
+| owner | Yes | vector, raster, 3d, app, dem, infra, common | Who is the owner of the deployment |
+| gisDomain | No | vector, raster, 3d, dem, terrain-analysis | To what GIS domain it is related |
+| releaseVersion | No | semantic version (e.g., v1.0.0) | The MapColonies project product version |
+
+## Maintainers
+
+### File Structure
+- `templates/_helpers.tpl`: Contains helper functions for generating labels and annotations.
+- `templates/_setValues.tpl`: Contains functions for merging and setting mcLabels values.
+- `templates/_validations.tpl`: Contains validation functions for mcLabels values.
+
+### Adding New Labels Or Annotations
+1. Add the labels or annotations in `templates/_helpers.tpl`.
+
+### Adding New Validations
+1. Define valid values in `templates/_setValues.tpl`.
+2. Add validation logic in `templates/_validations.tpl`.
+
+### Updating the Chart Version
+1. Update the version in `Chart.yaml`.
+2. Update the version in the `README.md` installation instructions.
+
+### Testing Changes
+1. Make changes to the templates.
+2. Run `helm lint` to validate the chart.
+3. Deploy the chart in a test environment to ensure it works as expected.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ metadata:
     {{ include "mc-labels-and-annotations.annotations" . | nindent 4 }}
 ```
 
+For service component, use these functions instead:
+```yaml
+metadata:
+  labels:
+    {{ include "mc-labels-and-annotations.serviceLabels" . | nindent 4 }}
+  annotations:
+    {{ include "mc-labels-and-annotations.serviceAnnotations" . | nindent 4 }}
+```
+
 ### Configuration
 Define "mcLabels" in `values.yaml`. Values can be set globally or overridden locally:
 

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,144 +1,66 @@
 {{/*
-Expand the name of the chart.
+Create common labels for all kubernetes components
 */}}
-{{- define "mcMetadata.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- define "generalLabels" -}}
+{{- include "validateGeneral" . }}
+{{- include "selectorLabels" . }}
+{{ $mcLabels := fromYaml (include "mcLabels.merged" .) -}}
+app.kubernetes.io/part-of: {{ $mcLabels.partOf }}
+mapcolonies.io/owner: {{ $mcLabels.owner }}
+app.kubernetes.io/created-by: {{ $mcLabels.createdBy }}
+{{- if hasKey $mcLabels "releaseVersion" }}
+mapcolonies.io/release-version: {{ $mcLabels.releaseVersion }}
 {{- end -}}
-
-{{/*
-Returns the createdBy from global mcMetadata if exists or from the mcMetadata's values
-*/}}
-{{- define "mcMetadata.createdBy" -}}
-    {{- if (hasKey .Values.global.mcMetadata "createdBy") -}}
-        {{- .Values.global.mcMetadata.createdBy -}}
-    {{- else -}}
-        {{- .Values.mcMetadata.createdBy -}}
-    {{- end -}}
+{{ if hasKey $mcLabels "gisDomain" }}
+mapcolonies.io/gis-domain: {{ $mcLabels.gisDomain }}
 {{- end -}}
-
-{{/*
-Returns the component from global mcMetadata if exists or from the mcMetadata's values
-*/}}
-{{- define "mcMetadata.component" -}}
-    {{- if (hasKey .Values.global.mcMetadata "component") -}}
-        {{- .Values.global.mcMetadata.component -}}
-    {{- else -}}
-        {{- .Values.mcMetadata.component -}}
-    {{- end -}}
-{{- end -}}
-
-{{/*
-Returns the partOf from global mcMetadata if exists or from the mcMetadata's values
-*/}}
-{{- define "mcMetadata.partOf" -}}
-    {{- if (hasKey .Values.global.mcMetadata "partOf") -}}
-        {{- .Values.global.mcMetadata.partOf -}}
-    {{- else -}}
-        {{- .Values.mcMetadata.partOf -}}
-    {{- end -}}
-{{- end -}}
-
-{{/*
-Returns the releaseVersion from global mcMetadata if exists or from the mcMetadata's values
-*/}}
-{{- define "mcMetadata.releaseVersion" -}}
-    {{- if (hasKey .Values.global.mcMetadata "releaseVersion") -}}
-        {{- .Values.global.mcMetadata.releaseVersion -}}
-    {{- else -}}
-        {{- .Values.mcMetadata.releaseVersion -}}
-    {{- end -}}
-{{- end -}}
-
-{{/*
-Returns the owner from global mcMetadata if exists or from the mcMetadata's values
-*/}}
-{{- define "mcMetadata.owner" -}}
-    {{- if (hasKey .Values.global.mcMetadata "owner") -}}
-        {{- .Values.global.mcMetadata.owner -}}
-    {{- else -}}
-        {{- .Values.mcMetadata.owner -}}
-    {{- end -}}
-{{- end -}}
-
-{{/*
-Returns the gisDomain from global mcMetadata if exists or from the mcMetadata's values
-*/}}
-{{- define "mcMetadata.gisDomain" -}}
-    {{- if (hasKey .Values.global.mcMetadata "gisDomain") -}}
-        {{- .Values.global.mcMetadata.gisDomain -}}
-    {{- else -}}
-        {{- .Values.mcMetadata.gisDomain -}}
-    {{- end -}}
-{{- end -}}
-
-{{/*
-Returns the environment from global if exists or from the chart's values, defaults to development
-*/}}
-{{- define "mcMetadata.environment" -}}
-    {{- if (hasKey .Values "environment") -}}
-        {{- .Values.environment -}}
-    {{- else -}}
-        {{- .Values.global.environment -}}
-    {{- end -}}
-{{- end -}}
-
-{{- define "mc-labels-and-annotations.generalLabels" -}}
-{{- $environment := include "mcMetadata.environment" . | trim }}
-{{- $name := include "mcMetadata.name" . | trim }}
-{{- $createdBy := include "mcMetadata.createdBy" . | trim }}
-{{- $component := include "mcMetadata.component" . | trim }}
-{{- $partOf := include "mcMetadata.partOf" . | trim }}
-{{- $releaseVersion := include "mcMetadata.releaseVersion" . | trim }}
-{{- $owner := include "mcMetadata.owner" . | trim }}
-{{- $gisDomain := include "mcMetadata.gisDomain" . | trim }}
-
-app.kubernetes.io/name: "{{ $name }}"
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/created-by: "{{ $createdBy }}"
-app.kubernetes.io/part-of: "{{ $partOf }}"
-mapcolonies.io/environment: "{{ $environment }}"
-mapcolonies.io/release-version: "{{ $releaseVersion }}"
-mapcolonies.io/owner: "{{ $owner }}"
-mapcolonies.io/gis-domain: "{{ $gisDomain }}"
 {{- end }}
 
+{{/*
+Create common annotations for all kubernetes components
+*/}}
+{{- define "generalAnnotations" -}}
+{{- end }}
+
+{{/*
+Create common labels for all kubernetes components
+*/}}
+{{- define "selectorLabels" -}}
+{{- $mcLabels := fromYaml (include "mcLabels.merged" .) -}}
+mapcolonies.io/environment: {{ $mcLabels.environment }}
+{{- end }}
+
+{{/*
+Create common labels for all kubernetes components besides service.
+It includes also the common labels from "generalLabels" function
+*/}}
 {{- define "mc-labels-and-annotations.labels" -}}
-{{- include "mc-labels-and-annotations.validateLabelsAndAnnotations" . }}
-{{- include "mc-labels-and-annotations.generalLabels" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/version: {{ .Chart.AppVersion }}
-helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-app.kubernetes.io/component: "{{ .Values.mcMetadata.component }}"
+{{- include "validate" . }}
+{{- $mcLabels := fromYaml (include "mcLabels.merged" .) -}}
+{{- include "generalLabels" . }}
+app.kubernetes.io/component: {{ $mcLabels.component }}
 {{- end }}
 
-{{- define "mc-labels-and-annotations.serviceLabels" -}}
-{{- include "mc-labels-and-annotations.generalLabels" . }}
-{{- end }}
-
+{{/*
+Create common annotations for all kubernetes components besides service.
+It includes also the common annotations from "generalAnnotations" function
+*/}}
 {{- define "mc-labels-and-annotations.annotations" -}}
+{{- include "generalAnnotations" . }}
 {{- end }}
 
-{{- define "mc-labels-and-annotations.validateLabelsAndAnnotations" -}}
+{{/*
+Create common labels for kubernetes service component.
+It includes also the common labels from "generalLabels" function
+*/}}
+{{- define "mc-labels-and-annotations.serviceLabels" -}}
+{{- include "generalLabels" . }}
+{{- end }}
 
-{{- $environment := include "mcMetadata.environment" . | trim }}
-{{- $component := include "mcMetadata.component" . | trim }}
-{{- $owner := include "mcMetadata.owner" . | trim }}
-{{- $gisDomain := include "mcMetadata.gisDomain" . | trim }}
-
-  {{- if not (has $component (list "frontend" "backend" "database" "proxy-server" "cache-server" "infrastructure")) -}}
-      {{- fail (printf "Invalid value for mapcolonies.io/component:") -}}
-  {{- end -}}
-
-  {{- if not (has $gisDomain (list "vector" "raster" "3d" "dem" "terrain-analysis")) -}}
-      {{- fail (printf "Invalid value for mapcolonies.io/gisDomain:") -}}
-  {{- end -}}
-
-  {{- if not (has $environment (list "dev" "prod" "integration")) -}}
-      {{- fail (printf "Invalid value for mapcolonies.io/environment: %s" $environment) -}}
-  {{- end -}}
-  
-  {{- if not (has $owner (list "vector" "raster" "3d" "app" "dem" "infra" "common")) -}}
-      {{- fail (printf "Invalid value for mapcolonies.io/owner:") -}}
-  {{- end -}}
-
-{{- end -}}
+{{/*
+Create common annotations for kubernetes service component.
+It includes also the common annotations from "generalAnnotations" function
+*/}}
+{{- define "mc-labels-and-annotations.serviceAnnotations" -}}
+{{- include "generalAnnotations" . }}
+{{- end }}

--- a/helm/templates/_setValues.tpl
+++ b/helm/templates/_setValues.tpl
@@ -1,0 +1,31 @@
+{{/*
+Defines valid values for different fields
+*/}}
+{{- define "components" -}}
+{{- join " " (list "frontend" "backend" "database" "proxy-server" "cache-server" "infrastructure") -}}
+{{- end -}}
+
+{{- define "gisDomains" -}}
+{{- join " " (list "vector" "raster" "3d" "dem" "terrain-analysis") -}}
+{{- end -}}
+
+{{- define "environments" -}}
+{{- join " " (list "development" "production" "stage") -}}
+{{- end -}}
+
+{{- define "owners" -}}
+{{- join " " (list "vector" "raster" "3d" "app" "dem" "infra" "common") -}}
+{{- end -}}
+
+{{/*
+Merge global and local mcLabels values
+*/}}
+{{- define "mcLabels.merged" -}}
+{{- if not (or .Values.global.mcLabels .Values.mcLabels) -}}
+    {{- fail (printf "There is no mcLabels key (locally or globally)") -}}
+{{- end -}}
+{{- $globalMcLabels := default (dict) .Values.global.mcLabels -}}
+{{- $localMcLabels := default (dict) .Values.mcLabels -}}
+{{- $merged := merge $localMcLabels $globalMcLabels -}}
+{{- $merged | toYaml -}}
+{{- end -}}

--- a/helm/templates/_validations.tpl
+++ b/helm/templates/_validations.tpl
@@ -1,0 +1,52 @@
+{{/*
+Validates mcLabels values needed for general labels and annotations
+*/}}
+{{- define "validateGeneral" -}}
+{{- $mcLabels := include "mcLabels.merged" . | fromYaml -}}
+
+{{- if not (hasKey $mcLabels "environment") -}}
+    {{- fail "There is no environment key in mcLabels" -}}
+{{- end -}}
+{{- if not (hasKey $mcLabels "createdBy") -}}
+    {{- fail "There is no createdBy key in mcLabels" -}}
+{{- end -}}
+{{- if not (hasKey $mcLabels "partOf") -}}
+    {{- fail "There is no partOf key in mcLabels" -}}
+{{- end -}}
+{{- if not (hasKey $mcLabels "owner") -}}
+    {{- fail "There is no owner key in mcLabels" -}}
+{{- end -}}
+
+{{- $environments := splitList " " (include "environments" .) }}
+{{- $gisDomains := splitList " " (include "gisDomains" .) }}
+{{- $owners := splitList " " (include "owners" .) }}
+
+{{- if not (has $mcLabels.environment $environments) -}}
+    {{- fail (printf "Invalid value for mapcolonies.io/environment.\nProvided: %s \nValid values are: %s" $mcLabels.environment ($environments | join " | ")) -}}
+{{- end -}}
+
+{{- if not (has $mcLabels.owner $owners) -}}
+    {{- fail (printf "Invalid value for mapcolonies.io/owner.\nProvided: %s \nValid values are: %s" $mcLabels.owner ($owners | join " | ")) -}}
+{{- end -}}
+
+{{- if and (hasKey $mcLabels "gisDomain") (not (has $mcLabels.gisDomain $gisDomains)) -}}
+    {{- fail (printf "Invalid value for mapcolonies.io/gisDomain.\nProvided: %s \nValid values are: %s" $mcLabels.gisDomain ($gisDomains | join " | ")) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate mcLabels values needed for labels and annotations of all kubernetes components besides service
+*/}}
+{{- define "validate" -}}
+{{- $mcLabels := include "mcLabels.merged" . | fromYaml -}}
+
+{{- if not (hasKey $mcLabels "component") -}}
+    {{- fail "There is no component key in mcLabels" -}}
+{{- end -}}
+
+{{- $components := splitList " " (include "components" .) }}
+
+{{- if not (has $mcLabels.component $components) -}}
+    {{- fail (printf "Invalid value for mapcolonies.io/component.\nProvided: %s \nValid values are: %s" $mcLabels.component ($components | join " | ")) -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
This PR refactors the mc-labels-and-annotations Helm chart to improve maintainability and usability. The changes include merging global and local mcLabels values, adding validation functions, and updating the README to reflect the new structure