### PR TITLE
fix: naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mcLabelsAndAnnotations
+# mc-labels-and-annotations
 
 This Helm chart provides MapColonies predefined labels and annotations through helper templates to streamline Kubernetes application deployments.
 
@@ -14,7 +14,7 @@ Add this chart as a dependency in your `Chart.yaml`:
 <!-- x-release-please-start-version -->
 ```yaml
 dependencies:
-  - name: mcLabelsAndAnnotations
+  - name: mc-labels-and-annotations
     version: 0.5.0
     repository: oci://acrarolibotnonprod.azurecr.io/helm/infra
 ```
@@ -27,7 +27,7 @@ helm dependency update
 ## Usage
 
 ### Template Integration
-Add these functions `{{ include "mcLabelsAndAnnotations.labels" . }}` and `{{ include "mcLabelsAndAnnotations.selectorLabels" . }}` to your labels and selectorLabels functions respectively under `_helpers.tpl` file:
+Add these functions `{{ include "mc-labels-and-annotations.labels" . }}` and `{{ include "mc-labels-and-annotations.selectorLabels" . }}` to your labels and selectorLabels functions respectively under `_helpers.tpl` file:
 
 ```yaml
 {{/*
@@ -37,7 +37,7 @@ Common labels
 ...
 YOUR CODE
 ...
-{{ include "mcLabelsAndAnnotations.labels" . }}
+{{ include "mc-labels-and-annotations.labels" . }}
 {{- end }}
 ```
 
@@ -50,7 +50,7 @@ Selector labels
 YOUR CODE
 ...
 
-{{ include "mcLabelsAndAnnotations.selectorLabels" . }}
+{{ include "mc-labels-and-annotations.selectorLabels" . }}
 {{- end }}
 ```
 
@@ -58,19 +58,19 @@ If you want to add also annotations (for example, enabling metrics annotations),
 ```yaml
 metadata:
   annotations:
-    {{ include "mcLabelsAndAnnotations.annotations" . | nindent 4 }}
+    {{ include "mc-labels-and-annotations.annotations" . | nindent 4 }}
 ```
 
 ### Configuration
-Define "mcLabelsAndAnnotations" in `values.yaml`. Some values can be set globally and can be overridden locally for specific cases
+Define "mc-labels-and-annotations" in `values.yaml`. Some values can be set globally and can be overridden locally for specific cases
 
 ```yaml
 global:
-  mcLabelsAndAnnotations:
+  mc-labels-and-annotations:
     environment: "development"
 
-mcLabelsAndAnnotations:
-  environment: "stage" # Overrides global.mcLabelsAndAnnotations.environment
+mc-labels-and-annotations:
+  environment: "stage" # Overrides global.mc-labels-and-annotations.environment
   owner: "3d"
 ```
 
@@ -93,7 +93,7 @@ The chart validates the following metadata fields:
 
 ### File Structure
 - `templates/_helpers.tpl`: Contains helper functions for generating labels and annotations.
-- `templates/_setValues.tpl`: Contains functions for merging and setting mcLabelsAndAnnotations values.
+- `templates/_setValues.tpl`: Contains functions for merging and setting mc-labels-and-annotations values.
 
 ### Adding New Labels Or Annotations
 1. Add the labels or annotations in `templates/_helpers.tpl`.

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: mcLabelsAndAnnotations
+name: mc-labels-and-annotations
 description: >-
   A MapColonies' helm library chart for creating and validating Kubernetes
   labels and annotations.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,14 +1,14 @@
 {{/*
 Create common labels for all kubernetes components
 */}}
-{{- define "mcLabelsAndAnnotations.selectorLabels" -}}
+{{- define "mc-labels-and-annotations.selectorLabels" -}}
 mapcolonies.io/environment: {{ include "environmentMerged" . }}
 {{- end }}
 
 {{/*
 Create common labels for all kubernetes components
 */}}
-{{- define "mcLabelsAndAnnotations.labels" -}}
+{{- define "mc-labels-and-annotations.labels" -}}
 mapcolonies.io/part-of: {{ .Values.mcLabelsAndAnnotations.partOf }}
 mapcolonies.io/owner: {{ .Values.mcLabelsAndAnnotations.owner }}
 mapcolonies.io/component: {{ .Values.mcLabelsAndAnnotations.component }}
@@ -20,7 +20,7 @@ mapcolonies.io/gis-domain: {{ .Values.mcLabelsAndAnnotations.gisDomain }}
 {{/*
 Create common annotations for all kubernetes components
 */}}
-{{- define "mcLabelsAndAnnotations.annotations" -}}
+{{- define "mc-labels-and-annotations.annotations" -}}
 prometheus.io/scrape: {{ coalesce .Values.mcLabelsAndAnnotations.metricsEnabled "true" | quote }}
 prometheus.io/port: {{ coalesce .Values.mcLabelsAndAnnotations.metricsPort "8080" | quote }}
 prometheus.io/path: {{ coalesce .Values.mcLabelsAndAnnotations.metricsPath "/metrics" | quote }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,7 +13,7 @@
         {
           "type": "yaml",
           "path": "test-helm/Chart.yaml",
-          "jsonpath": "$.dependencies.version"
+          "jsonpath": "$.dependencies[0].version"
         },
         "README.md"
       ]

--- a/test-helm/Chart.lock
+++ b/test-helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: mcLabelsAndAnnotations
+- name: mc-labels-and-annotations
   repository: file://../helm
-  version: 0.4.0
-digest: sha256:1e2ca72b5ebb2a610e8466e04ba79091f18e4228e88b7c4019782023488e8ada
-generated: "2025-06-22T19:40:02.115365551+03:00"
+  version: 0.5.0
+digest: sha256:2f34ab9feb3852eb9447bc7407c80d250935e649a0251248922b8e3166274e13
+generated: "2025-06-25T12:03:28.610430821+03:00"

--- a/test-helm/Chart.yaml
+++ b/test-helm/Chart.yaml
@@ -23,6 +23,7 @@ version: 0.1.0
 # It is recommended to use it with quotes.
 appVersion: "1.16.0"
 dependencies:
-  - name: mcLabelsAndAnnotations
-    version: 0.4.0
+  - name: mc-labels-and-annotations
+    version: 0.5.0
     repository: file://../helm
+    alias: mcLabelsAndAnnotations

--- a/test-helm/templates/_helpers.tpl
+++ b/test-helm/templates/_helpers.tpl
@@ -40,7 +40,7 @@ helm.sh/chart: {{ include "test-helm.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{ include "mcLabelsAndAnnotations.labels" . }}
+{{ include "mc-labels-and-annotations.labels" . }}
 {{- end }}
 
 {{/*
@@ -49,7 +49,7 @@ Selector labels
 {{- define "test-helm.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "test-helm.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{ include "mcLabelsAndAnnotations.selectorLabels" . }}
+{{ include "mc-labels-and-annotations.selectorLabels" . }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Update all references to use the kebab-case naming convention for the mcLabelsAndAnnotations Helm chart. This change enhances consistency and clarity in the codebase and fixes pushing to registry.