### PR TITLE
feat: add prometheus metrics support and environment handling

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -21,7 +21,9 @@ mapcolonies.io/gis-domain: {{ .Values.mcLabelsAndAnnotations.gisDomain }}
 Create common annotations for all kubernetes components
 */}}
 {{- define "mc-labels-and-annotations.annotations" -}}
-prometheus.io/scrape: {{ coalesce .Values.mcLabelsAndAnnotations.metricsEnabled "true" | quote }}
-prometheus.io/port: {{ coalesce .Values.mcLabelsAndAnnotations.metricsPort "8080" | quote }}
-prometheus.io/path: {{ coalesce .Values.mcLabelsAndAnnotations.metricsPath "/metrics" | quote }}
+{{- if and (hasKey .Values.mcLabelsAndAnnotations "prometheus") .Values.mcLabelsAndAnnotations.prometheus.enabled }}
+prometheus.io/scrape: "true"
+prometheus.io/port: {{ coalesce .Values.mcLabelsAndAnnotations.prometheus.port "8080" | quote }}
+prometheus.io/path: {{ coalesce .Values.mcLabelsAndAnnotations.prometheus.path "/metrics" | quote }}
+{{- end }}
 {{- end }}

--- a/helm/templates/_setValues.tpl
+++ b/helm/templates/_setValues.tpl
@@ -5,6 +5,6 @@
 {{- else if (and (hasKey .Values "global") (hasKey .Values.global "mcLabelsAndAnnotations") (hasKey .Values.global.mcLabelsAndAnnotations "environment")) -}}
 {{- .Values.global.mcLabelsAndAnnotations.environment -}}
 {{- else -}}
-{{- fail "There is no environment key in mcLabelsAndAnnotations, globally or locally" -}}
+undefined
 {{- end -}}
 {{- end -}}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -36,23 +36,29 @@
       "enum": ["vector", "raster", "3d", "dem", "terrain-analysis"],
       "description": "The GIS domain this deployment relates to"
     },
-    "metricsEnabled": {
-      "type": "boolean",
-      "default": true,
-      "description": "Whether metrics are enabled for this deployment"
-    },
-    "metricsPort": {
-      "type": "integer",
-      "minimum": 1,
-      "maximum": 65535,
-      "default": 8080,
-      "description": "The port on which metrics are exposed"
-    },
-    "metricsPath": {
-      "type": "string",
-      "pattern": "^/",
-      "default": "/metrics",
-      "description": "The path on which metrics are exposed"
+    "prometheus": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether Prometheus metrics are enabled for this deployment"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 8080,
+          "description": "The port on which Prometheus metrics are exposed"
+        },
+        "path": {
+          "type": "string",
+          "pattern": "^/",
+          "default": "/metrics",
+          "description": "The path on which Prometheus metrics are exposed"
+        }
+      },
+      "required": ["enabled"]
     }
   }
 }

--- a/test-helm/Chart.lock
+++ b/test-helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mc-labels-and-annotations
   repository: file://../helm
-  version: 0.5.1
-digest: sha256:70af9122996a245f4996e51463de5a041347d5880d0bfb529b60799435b112f0
-generated: "2025-06-26T17:14:03.299290219+03:00"
+  version: 0.6.0
+digest: sha256:d946182bb330829b1f2dbff7f05c5712505dbd792f758813d7cc738b2cfa3df6
+generated: "2025-07-01T11:36:42.421432335+03:00"

--- a/test-helm/templates/deployment.yaml
+++ b/test-helm/templates/deployment.yaml
@@ -14,8 +14,9 @@ spec:
       {{- include "test-helm.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{ include "mc-labels-and-annotations.annotations" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/test-helm/tests/annotations_test.yaml
+++ b/test-helm/tests/annotations_test.yaml
@@ -1,16 +1,62 @@
 suite: test annotations
 tests:
-  - it: Should render annotations (currently none)
+  - it: Should not include Prometheus annotations by default
     set:
-      mcLabelsAndAnnotations: # Need this block to pass general validation
+      mcLabelsAndAnnotations:
         environment: development
         component: backend
         partOf: myApplication
         owner: infra
     asserts:
       - template: deployment.yaml
-        isKind:
-          of: Deployment
-      - template: service.yaml
-        isKind:
-          of: Service
+        notEqual:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "false"
+            
+  - it: Should include default Prometheus annotations when prometheus.enabled is true
+    set:
+      mcLabelsAndAnnotations:
+        environment: development
+        component: backend
+        partOf: myApplication
+        owner: infra
+        prometheus:
+          enabled: true
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "8080"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["prometheus.io/path"]
+          value: "/metrics"
+
+  - it: Should include Prometheus annotations when prometheus.enabled is true and has values
+    set:
+      mcLabelsAndAnnotations:
+        environment: development
+        component: backend
+        partOf: myApplication
+        owner: infra
+        prometheus:
+          enabled: true
+          port: 90
+          path: /custom-metrics
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "90"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["prometheus.io/path"]
+          value: "/custom-metrics"

--- a/test-helm/tests/labels_test.yaml
+++ b/test-helm/tests/labels_test.yaml
@@ -71,3 +71,23 @@ tests:
       - equal:
           path: metadata.labels["mapcolonies.io/gis-domain"]
           value: 3d
+
+  - it: Should set environment to undefined when not provided
+    set:
+      mcLabelsAndAnnotations:
+        component: frontend
+        partOf: anotherApp
+        owner: raster
+    asserts:
+      - equal:
+          path: metadata.labels["mapcolonies.io/environment"]
+          value: undefined
+      - equal:
+          path: metadata.labels["mapcolonies.io/component"]
+          value: frontend
+      - equal:
+          path: metadata.labels["mapcolonies.io/part-of"]
+          value: anotherApp
+      - equal:
+          path: metadata.labels["mapcolonies.io/owner"]
+          value: raster

--- a/test-helm/tests/validations_test.yaml
+++ b/test-helm/tests/validations_test.yaml
@@ -1,19 +1,8 @@
 suite: test validations
 tests:
-  - it: Should fail if environment is missing
-    set:
-      mcLabelsAndAnnotations:
-        component: backend
-        partOf: myApplication
-        owner: infra
-    asserts:
-      - failedTemplate:
-          errorMessage: "There is no environment key in mcLabelsAndAnnotations, globally or locally"
-
   - it: Should fail if partOf is missing
     set:
       mcLabelsAndAnnotations:
-        environment: development
         component: backend
         owner: infra
     asserts:
@@ -23,7 +12,6 @@ tests:
   - it: Should fail if owner is missing
     set:
       mcLabelsAndAnnotations:
-        environment: development
         component: backend
         partOf: myApplication
     asserts:
@@ -33,7 +21,6 @@ tests:
   - it: Should fail if component is missing
     set:
       mcLabelsAndAnnotations:
-        environment: development
         partOf: myApplication
         owner: infra
     asserts:


### PR DESCRIPTION
Introduce support for Prometheus metrics configuration, allowing users to enable metrics and specify custom ports and paths. Update environment handling to return 'undefined' when not provided, enhancing flexibility in deployment configurations.